### PR TITLE
Upgrading OneNote library to .NET Standard

### DIFF
--- a/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.csproj
+++ b/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.csproj
@@ -1,42 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B463D0CB-8EE1-4D64-96FA-D74EAAA4A83F}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ScipBe.Common.Office.Excel</RootNamespace>
-    <AssemblyName>ScipBe.Common.Office.Excel</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <NoWarn>1591</NoWarn>
     <DocumentationFile>bin\Debug\ScipBe.Common.Office.Excel.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ScipBe.Common.Office\Excel\ExcelColumn.cs">
       <Link>ExcelColumn.cs</Link>
@@ -59,10 +30,9 @@
     <Compile Include="..\ScipBe.Common.Office\Excel\IExcelRow.cs">
       <Link>IExcelRow.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="ScipBe.Common.Office.Excel.nuspec" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.OleDb" Version="6.0.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.csproj
+++ b/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.csproj
@@ -1,48 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{028C2546-1FE2-43C8-B27E-C61C4CB4893A}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ScipBe.Common.Office.OneNote</RootNamespace>
-    <AssemblyName>ScipBe.Common.Office.OneNote</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\ScipBe.Common.Office.OneNote.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Interop.Microsoft.Office.Interop.OneNote, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Interop.Microsoft.Office.Interop.OneNote.1.1.0.0\lib\net40\Interop.Microsoft.Office.Interop.OneNote.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ScipBe.Common.Office\OneNote\IOneNoteExtNotebook.cs">
       <Link>IOneNoteExtNotebook.cs</Link>
@@ -89,11 +54,9 @@
     <Compile Include="..\ScipBe.Common.Office\Utils\StringExtensions.cs">
       <Link>StringExtensions.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="ScipBe.Common.Office.OneNote.nuspec" />
+    <PackageReference Include="Interop.Microsoft.Office.Interop.OneNote" Version="1.1.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.csproj
+++ b/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.csproj
@@ -56,7 +56,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Interop.Microsoft.Office.Interop.OneNote" Version="1.1.0.0" />
+    <PackageReference Include="Interop.Microsoft.Office.Interop.OneNote" Version="1.1.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Src/ScipBe.Common.Office.OneNote/packages.config
+++ b/Src/ScipBe.Common.Office.OneNote/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0.0" targetFramework="net461" />
-</packages>

--- a/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.csproj
+++ b/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.csproj
@@ -1,46 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{1894C924-B24A-4D92-8567-02E12958FC92}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ScipBe.Common.Office.Outlook</RootNamespace>
-    <AssemblyName>ScipBe.Common.Office.Outlook</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <NoWarn>1591</NoWarn>
     <DocumentationFile>bin\Debug\ScipBe.Common.Office.Outlook.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.Office.Interop.Outlook.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Outlook.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ScipBe.Common.Office\Outlook\ContactItemExtensions.cs">
       <Link>ContactItemExtensions.cs</Link>
@@ -54,11 +21,9 @@
     <Compile Include="..\ScipBe.Common.Office\Outlook\OutlookProvider.cs">
       <Link>OutlookProvider.cs</Link>
     </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="ScipBe.Common.Office.Outlook.nuspec" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Office.Interop.Outlook" Version="15.0.4797.1003" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Src/ScipBe.Common.Office.Outlook/packages.config
+++ b/Src/ScipBe.Common.Office.Outlook/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" targetFramework="net461" />
-</packages>

--- a/Src/ScipBe.Common.Office.Tests/Excel/ExcelProvidertTest.cs
+++ b/Src/ScipBe.Common.Office.Tests/Excel/ExcelProvidertTest.cs
@@ -68,7 +68,7 @@ namespace ScipBe.Common.Office.Tests
             Assert.AreEqual("Peter", excel.Rows.Last().Get<string>("B"));
             Assert.AreEqual("Peter", excel.Rows.Last().GetByName<string>("FirstName"));
 
-            Assert.AreEqual(DateTime.Parse("3/05/1979 0:00:00"), excel.Rows.Last().GetByName<DateTime>("BirthDate"));
+            Assert.AreEqual(DateTime.Parse("1979-05-03 0:00:00"), excel.Rows.Last().GetByName<DateTime>("BirthDate"));
         }
     }
 }

--- a/Src/ScipBe.Common.Office.Tests/OneNote/OneNoteProviderTest.cs
+++ b/Src/ScipBe.Common.Office.Tests/OneNote/OneNoteProviderTest.cs
@@ -18,7 +18,7 @@ namespace ScipBe.Common.Office.Tests
             var notebooks = oneNoteProvider.NotebookItems;
 
             // Arrange
-            Assert.IsTrue(notebooks.Count() > 0);
+            Assert.IsTrue(notebooks.Any());
         }
 
         [TestMethod]
@@ -31,7 +31,7 @@ namespace ScipBe.Common.Office.Tests
             var pages = oneNoteProvider.PageItems;
 
             // Arrange
-            Assert.IsTrue(pages.Count() > 0);
+            Assert.IsTrue(pages.Any());
         }
 
         [TestMethod]
@@ -58,6 +58,20 @@ namespace ScipBe.Common.Office.Tests
 
             // Arrange
             Assert.IsTrue(pages.Any());
+        }
+
+        [TestMethod]
+        public void GetContent()
+        {
+            // Arrange
+            var oneNoteProvider = new OneNoteProvider();
+
+            // Act
+            var page = oneNoteProvider.PageItems.First();
+            oneNoteProvider.OneNote.GetPageContent(page.ID, out string content);
+
+            // Arrange
+            Assert.IsFalse(string.IsNullOrWhiteSpace(content));
         }
     }
 }

--- a/Src/ScipBe.Common.Office.Tests/Outlook/OutlookProvidertTest.cs
+++ b/Src/ScipBe.Common.Office.Tests/Outlook/OutlookProvidertTest.cs
@@ -18,7 +18,7 @@ namespace ScipBe.Common.Office.Tests
             var folders = outlook.Folders;
 
             // Assert
-            Assert.IsTrue(outlook.Folders.Count() > 0);
+            Assert.IsTrue(outlook.Folders.Any());
         }
 
         [TestMethod]
@@ -31,7 +31,7 @@ namespace ScipBe.Common.Office.Tests
             var contactItems = outlook.ContactItems;
 
             // Assert
-            Assert.IsTrue(contactItems.Count() > 0);
+            Assert.IsTrue(contactItems.Any());
         }
 
         [TestMethod]
@@ -44,7 +44,7 @@ namespace ScipBe.Common.Office.Tests
             var calendarItems = outlook.CalendarItems;
 
             // Assert
-            Assert.IsTrue(calendarItems.Count() > 0);
+            Assert.IsTrue(calendarItems.Any());
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace ScipBe.Common.Office.Tests
             var inboxItems = outlook.InboxItems;
 
             // Assert
-            Assert.IsTrue(inboxItems.Count() > 0);
+            Assert.IsTrue(inboxItems.Any());
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace ScipBe.Common.Office.Tests
             var sentMailItems = outlook.SentMailItems;
 
             // Assert
-            Assert.IsTrue(sentMailItems.Count() > 0);
+            Assert.IsTrue(sentMailItems.Any());
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace ScipBe.Common.Office.Tests
             var mailItems = outlook.GetItems<MailItem>(folder);
 
             // Assert
-            Assert.IsTrue(mailItems.Count() > 0);
+            Assert.IsTrue(mailItems.Any());
         }
 
         [TestMethod]
@@ -98,7 +98,7 @@ namespace ScipBe.Common.Office.Tests
             var appointmentItems = outlook.GetItems<AppointmentItem>(folder.FolderPath);
 
             // Assert
-            Assert.IsTrue(appointmentItems.Count() > 0);
+            Assert.IsTrue(appointmentItems.Any());
         }
     }
 }

--- a/Src/ScipBe.Common.Office.Tests/ScipBe.Common.Office.Tests.csproj
+++ b/Src/ScipBe.Common.Office.Tests/ScipBe.Common.Office.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,6 +19,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,19 +39,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Interop.Microsoft.Office.Interop.OneNote, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Interop.Microsoft.Office.Interop.OneNote.1.1.0.0\lib\net40\Interop.Microsoft.Office.Interop.OneNote.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
       <HintPath>..\packages\Microsoft.Office.Interop.Outlook.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Outlook.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.OleDb, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.OleDb.6.0.0\lib\net461\System.Data.OleDb.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Drawing.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.6.0.0\lib\net461\System.Drawing.Common.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Excel\ExcelProvidertTest.cs" />
@@ -83,17 +94,17 @@
     <ProjectReference Include="..\ScipBe.Common.Office\ScipBe.Common.Office.csproj">
       <Project>{233d48e6-9618-4861-bd45-683ba450341c}</Project>
       <Name>ScipBe.Common.Office</Name>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Src/ScipBe.Common.Office.Tests/packages.config
+++ b/Src/ScipBe.Common.Office.Tests/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0.0" targetFramework="net461" />
   <package id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" targetFramework="net461" />
-  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net462" />
+  <package id="System.Data.OleDb" version="6.0.0" targetFramework="net462" />
+  <package id="System.Drawing.Common" version="6.0.0" targetFramework="net461" />
 </packages>

--- a/Src/ScipBe.Common.Office/Excel/IExcelProvider.cs
+++ b/Src/ScipBe.Common.Office/Excel/IExcelProvider.cs
@@ -22,12 +22,12 @@ namespace ScipBe.Common.Office.Excel
         /// <summary>
         /// Collection of definitions of Excel columns.
         /// </summary>
-        IEnumerable<IExcelColumn> Columns { get; }
+        List<IExcelColumn> Columns { get; }
 
         /// <summary>
         /// Collection of Excel rows.
         /// </summary>
-        IEnumerable<IExcelRow> Rows { get; }
+        List<IExcelRow> Rows { get; }
 
         /// <summary>
         /// Load XLSX, XLS or CSV file of given worksheet.

--- a/Src/ScipBe.Common.Office/ScipBe.Common.Office.csproj
+++ b/Src/ScipBe.Common.Office/ScipBe.Common.Office.csproj
@@ -1,27 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{233D48E6-9618-4861-BD45-683BA450341C}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ScipBe.Common.Office</RootNamespace>
-    <AssemblyName>ScipBe.Common.Office</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -37,86 +21,24 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\ScipBe.Common.Office.XML</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Interop.Microsoft.Office.Interop.OneNote, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Interop.Microsoft.Office.Interop.OneNote.1.1.0.0\lib\net40\Interop.Microsoft.Office.Interop.OneNote.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\packages\Microsoft.Office.Interop.Outlook.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Outlook.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
+    <Reference Update="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq">
+    <Reference Update="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Excel\ExcelColumn.cs" />
-    <Compile Include="Excel\ExcelProvider.cs" />
-    <Compile Include="Excel\ExcelRow.cs" />
-    <Compile Include="Excel\FileType.cs" />
-    <Compile Include="Excel\IExcelColumn.cs" />
-    <Compile Include="Excel\IExcelProvider.cs" />
-    <Compile Include="Excel\IExcelRow.cs" />
-    <Compile Include="OneNote\IOneNoteExtNotebook.cs" />
-    <Compile Include="OneNote\IOneNoteExtPage.cs" />
-    <Compile Include="OneNote\IOneNoteExtSection.cs" />
-    <Compile Include="OneNote\IOneNoteNotebook.cs" />
-    <Compile Include="OneNote\IOneNotePage.cs" />
-    <Compile Include="OneNote\IOneNoteProvider.cs" />
-    <Compile Include="OneNote\IOneNoteSection.cs" />
-    <Compile Include="OneNote\OneNoteExtNotebook.cs" />
-    <Compile Include="OneNote\OneNoteExtPage.cs" />
-    <Compile Include="OneNote\OneNoteExtSection.cs" />
-    <Compile Include="OneNote\OneNoteNotebook.cs" />
-    <Compile Include="OneNote\OneNotePage.cs" />
-    <Compile Include="OneNote\OneNoteProvider.cs" />
-    <Compile Include="OneNote\OneNoteSection.cs" />
-    <Compile Include="Outlook\OlItemTypeExtensions.cs" />
-    <Compile Include="Outlook\ContactItemExtensions.cs" />
-    <Compile Include="Outlook\IOutlookProvider.cs" />
-    <Compile Include="Outlook\OutlookProvider.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utils\StringExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Class Diagrams\ExcelProvider.cd">
+    <None Update="Class Diagrams\ExcelProvider.cd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Class Diagrams\OneNoteProvider.cd" />
-    <None Include="Class Diagrams\OutlookProvider.cd" />
-    <None Include="packages.config" />
-    <None Include="ScipBe.Common.Office.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
@@ -125,12 +47,10 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Interop.Microsoft.Office.Interop.OneNote" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Office.Interop.Outlook" Version="15.0.4797.1003" />
+    <PackageReference Include="System.Data.OleDb" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
 </Project>

--- a/Src/ScipBe.Common.Office/packages.config
+++ b/Src/ScipBe.Common.Office/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" targetFramework="net46" />
-</packages>


### PR DESCRIPTION
Fixes #7

* Converting Common, OneNote, Excel, and Outlook projects to .NET Standard 2.0. This will allow them to be consumed by both .NET Framework and .NET (Core) projects
* Fixing Excel tests to be runnable in US region (MM-DD-YYYY)
* Speeding up Outlook tests by using .Any() instead of .Count(). Any() doesn't require traversing the whole enumeration
* Cleaning up a few IDE code suggestions