### PR TITLE
Adding package dependencies

### DIFF
--- a/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.nuspec
+++ b/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.Excel</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Excel. Query Excel worksheets and CSV files.</summary>
     <description>The ExcelProvider loads an Excel worksheet or CSV file and provides column definition and row collections. All collections are IEnumerable so you can query them with LINQ. The ExcelProvider supports XLSX (Excel 2007-2016, v12-v16), XLS (Excel 97-2003, v8-v11) and CSV (comma, semicolumn or tab delimited ASCII file) files but it requires the installation of the Microsoft Access Database Engine 2010 Redistributable.</description>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.Excel.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office excel ado xlsx xls csv worksheet</tags>
   </metadata>
 </package>

--- a/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.nuspec
+++ b/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.OneNote</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to OneNote. Query Notebooks, Sections and Pages.</summary>
     <description>The OneNoteProvider provides collections of Notebooks, Sections and Pages by parsing the XML hierarchy tree of OneNote.</description>
@@ -10,8 +10,11 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.OneNote.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office onenote interop notebook section page</tags>
+    <dependencies>
+      <dependency id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0" />
+    </dependencies>
   </metadata>
 </package>
 

--- a/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.nuspec
+++ b/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.Outlook</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Outlook. Query Outlook Mails, Appointments, Contacts, ...</summary>
     <description>The OutlookProvider is a wrapper class which provides collections to data of Outlook (AppointmentItems, ContactItems, MailItems, TaskItems, ...). The OutlookProvider exposes collections of classes of the Microsoft.Office.Interop.Outlook assembly so you have full access to all properties and it also supports adding, updating and deleting data in Outlook.</description>
@@ -10,8 +10,11 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.Outlook.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office outlook interop mail contact appointment calendar agenda</tags>
+    <dependencies>
+      <dependency id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" />
+    </dependencies>
   </metadata>
 </package>
 

--- a/Src/ScipBe.Common.Office/ScipBe.Common.Office.nuspec
+++ b/Src/ScipBe.Common.Office/ScipBe.Common.Office.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Excel, LINQ to Outlook and LINQ to OneNote. Query data of Excel worksheets and CSV files, Outlook Mails, Appointments, Contacts, ... and OneNote Notebooks, Sections and Pages.</summary>
     <description>The ScipBe.Common.Office namespace contains 3 classes: ExcelProvider (LINQ to Excel), OutlookProvider (LINQ to Outlook) and OneNoteProvider (LINQ to OneNote). The ExcelProvider loads an Excel worksheet or CSV file and provides column definition and row collections. The OutlookProvider is a wrapper class which provides collections to data of Outlook (AppointmentItems, ContactItems, MailItems, TaskItems, ...). The OneNoteProvider provides collections of Notebooks, Sections and Pages by parsing the XML hierarchy tree of OneNote.  All collections are IEnumerable so you can query them with LINQ. There are also 3 separated NuGet packages with for the Excel, Outlook and OneNote provider so they can be used standalone.</description>
@@ -11,11 +11,15 @@
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.png</iconUrl>
     <releaseNotes>
-      Version 2.0.2 (May 2022)
+      Version 2.0.3 (May 2022)
       - Migrated to .NET Standard 2.0 to allow .NET Core projects to consume
       - Added FindPages API to OneNoteProvider, and OpenInOneNote method to OneNotePage
       - A couple bug fixes and improvements in the OneNote project and the unit tests
     </releaseNotes>
     <tags>scipbe linq office excel outlook onenote interop</tags>
+    <dependencies>
+      <dependency id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0" />
+      <dependency id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" />
+    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Turns out the <dependencies> for the package (the interop library) has to be explicitly specified, so I had to add those and update the versions to reupload to nuget. I have no idea why that wasn't necessary in previous versions?