### PR TITLE
Switching to a static class, and wrapping every method to release the COM helper

### DIFF
--- a/Doc/LinqPad/ScipBe.Common.Office.OneNote.linq
+++ b/Doc/LinqPad/ScipBe.Common.Office.OneNote.linq
@@ -7,17 +7,15 @@
 void Main()
 {
     Util.RawHtml($"<h2>ScipBe.Common.Office.OneNote - LINQ to OneNote - Query Notebooks, Sections and Pages</h2>").Dump();
-    
-	var oneNoteProvider = new OneNoteProvider();
 	
     // Find pages containing the word "onenote"
-    oneNoteProvider.FindPages("onenote")
+    OneNoteProvider.FindPages("onenote")
     .Select(p => new { NotebookName = p.Notebook.Name, SectionName = p.Section.Name, p.Name })
     .Dump("All OneNote Pages containing the word \"onenote\"");
     
 	// Show all encrypted OneNote Notebooks
 	var queryEncryptedSections = 
-	from nb in oneNoteProvider.NotebookItems
+	from nb in OneNoteProvider.NotebookItems
 	from s in nb.Sections
 	where s.Encrypted == true
 	select new { NotebookName = nb.Name, SectionName = s.Name };
@@ -25,24 +23,22 @@ void Main()
 	
 	// Show all OneNote Notebooks and the number of Sections they have
 	var queryNotebooks = 
-	(from nb in oneNoteProvider.NotebookItems
+	(from nb in OneNoteProvider.NotebookItems
 	select new { Notebook = nb.Name, SectionCount = nb.Sections.Count() })
 	.OrderByDescending(n => n.SectionCount);	
 	queryNotebooks.Dump("All OneNote Notebooks and the number of Sections they have");
 
 	// Show all OneNote Pages which have been modified last few days
 	var queryPages = 
-	from page in oneNoteProvider.PageItems
+	from page in OneNoteProvider.PageItems
 	where page.LastModified > DateTime.Now.AddMonths(-2)	
 	orderby page.LastModified descending
 	select new { NotebookName = page.Notebook.Name, SectionName = page.Section.Name, page.Name, page.LastModified };
 	queryPages.Dump("All OneNote Pages which have been modified last few days");	
 	
 	// Show XML content of the OneNote Pages which have been changed the last few days
-	foreach (var item in oneNoteProvider.PageItems.Where(p => p.LastModified > DateTime.Now.AddDays(-2)))
+	foreach (var item in OneNoteProvider.PageItems.Where(p => p.LastModified > DateTime.Now.AddDays(-2)))
 	{
-		var pageXMLContent = "";
-		oneNoteProvider.OneNote.GetPageContent(item.ID, out pageXMLContent, Microsoft.Office.Interop.OneNote.PageInfo.piBasic);
-        pageXMLContent.Dump($"{item.LastModified} {item.Notebook.Name} {item.Section.Name} {item.Name} {item.DateTime}");
+        item.GetContent().Dump($"{item.LastModified} {item.Notebook.Name} {item.Section.Name} {item.Name} {item.DateTime}");
 	}		
 }

--- a/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.nuspec
+++ b/Src/ScipBe.Common.Office.Excel/ScipBe.Common.Office.Excel.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.Excel</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Excel. Query Excel worksheets and CSV files.</summary>
     <description>The ExcelProvider loads an Excel worksheet or CSV file and provides column definition and row collections. All collections are IEnumerable so you can query them with LINQ. The ExcelProvider supports XLSX (Excel 2007-2016, v12-v16), XLS (Excel 97-2003, v8-v11) and CSV (comma, semicolumn or tab delimited ASCII file) files but it requires the installation of the Microsoft Access Database Engine 2010 Redistributable.</description>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.Excel.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office excel ado xlsx xls csv worksheet</tags>
   </metadata>
 </package>

--- a/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.nuspec
+++ b/Src/ScipBe.Common.Office.OneNote/ScipBe.Common.Office.OneNote.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.OneNote</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to OneNote. Query Notebooks, Sections and Pages.</summary>
     <description>The OneNoteProvider provides collections of Notebooks, Sections and Pages by parsing the XML hierarchy tree of OneNote.</description>
@@ -10,8 +10,11 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.OneNote.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office onenote interop notebook section page</tags>
+    <dependencies>
+      <dependency id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0" />
+    </dependencies>
   </metadata>
 </package>
 

--- a/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.nuspec
+++ b/Src/ScipBe.Common.Office.Outlook/ScipBe.Common.Office.Outlook.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office.Outlook</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Outlook. Query Outlook Mails, Appointments, Contacts, ...</summary>
     <description>The OutlookProvider is a wrapper class which provides collections to data of Outlook (AppointmentItems, ContactItems, MailItems, TaskItems, ...). The OutlookProvider exposes collections of classes of the Microsoft.Office.Interop.Outlook assembly so you have full access to all properties and it also supports adding, updating and deleting data in Outlook.</description>
@@ -10,8 +10,11 @@
     <projectUrl>https://github.com/scipbe/ScipBe-Common-Office</projectUrl>
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.Outlook.png</iconUrl>
-    <releaseNotes>Version 2.0.2 (May 2022)</releaseNotes>
+    <releaseNotes>Version 2.0.3 (May 2022)</releaseNotes>
     <tags>scipbe linq office outlook interop mail contact appointment calendar agenda</tags>
+    <dependencies>
+      <dependency id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" />
+    </dependencies>
   </metadata>
 </package>
 

--- a/Src/ScipBe.Common.Office.Tests/OneNote/OneNoteProviderTest.cs
+++ b/Src/ScipBe.Common.Office.Tests/OneNote/OneNoteProviderTest.cs
@@ -11,11 +11,8 @@ namespace ScipBe.Common.Office.Tests
         [TestMethod]
         public void Notebooks()
         {
-            // Arrange
-            var oneNoteProvider = new OneNoteProvider();
-
             // Act
-            var notebooks = oneNoteProvider.NotebookItems;
+            var notebooks = OneNoteProvider.NotebookItems;
 
             // Arrange
             Assert.IsTrue(notebooks.Any());
@@ -24,11 +21,8 @@ namespace ScipBe.Common.Office.Tests
         [TestMethod]
         public void Pages()
         {
-            // Arrange
-            var oneNoteProvider = new OneNoteProvider();
-
             // Act
-            var pages = oneNoteProvider.PageItems;
+            var pages = OneNoteProvider.PageItems;
 
             // Arrange
             Assert.IsTrue(pages.Any());
@@ -37,11 +31,8 @@ namespace ScipBe.Common.Office.Tests
         [TestMethod]
         public void EnumerateSections()
         {
-            // Arrange
-            var oneNoteProvider = new OneNoteProvider();
-
             // Act
-            var sections = oneNoteProvider.NotebookItems.SelectMany(n => n.Sections);
+            var sections = OneNoteProvider.NotebookItems.SelectMany(n => n.Sections);
 
             // Arrange
             Assert.IsTrue(sections.Any());
@@ -50,11 +41,8 @@ namespace ScipBe.Common.Office.Tests
         [TestMethod]
         public void FindPages()
         {
-            // Arrange
-            var oneNoteProvider = new OneNoteProvider();
-
             // Act
-            var pages = oneNoteProvider.FindPages("the");
+            var pages = OneNoteProvider.FindPages("the");
 
             // Arrange
             Assert.IsTrue(pages.Any());
@@ -63,12 +51,9 @@ namespace ScipBe.Common.Office.Tests
         [TestMethod]
         public void GetContent()
         {
-            // Arrange
-            var oneNoteProvider = new OneNoteProvider();
-
             // Act
-            var page = oneNoteProvider.PageItems.First();
-            oneNoteProvider.OneNote.GetPageContent(page.ID, out string content);
+            var page = OneNoteProvider.PageItems.First();
+            string content = page.GetContent();
 
             // Arrange
             Assert.IsFalse(string.IsNullOrWhiteSpace(content));

--- a/Src/ScipBe.Common.Office/OneNote/IOneNotePage.cs
+++ b/Src/ScipBe.Common.Office/OneNote/IOneNotePage.cs
@@ -33,8 +33,14 @@ namespace ScipBe.Common.Office.OneNote
         DateTime LastModified { get; }
 
         /// <summary>
+        /// Gets page content as an xml string.
+        /// </summary>
+        string GetContent();
+
+        /// <summary>
         /// Open this page in the OneNote app.
         /// </summary>
         void OpenInOneNote();
+
     }
 }

--- a/Src/ScipBe.Common.Office/OneNote/OneNotePage.cs
+++ b/Src/ScipBe.Common.Office/OneNote/OneNotePage.cs
@@ -18,6 +18,15 @@ namespace ScipBe.Common.Office.OneNote
         public DateTime DateTime { get; set; }
         public DateTime LastModified { get; set; }
 
+        public string GetContent()
+        {
+            return OneNoteProvider.CallOneNoteSafely(oneNote =>
+            {
+                oneNote.GetPageContent(this.ID, out string content);
+                return content;
+            });
+        }
+
         public void OpenInOneNote()
         {
             this.oneNote.NavigateTo(this.ID);

--- a/Src/ScipBe.Common.Office/OneNote/OneNoteProvider.cs
+++ b/Src/ScipBe.Common.Office/OneNote/OneNoteProvider.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
+using Microsoft.Office.Interop.OneNote;
 using ScipBe.Common.Office.Utils;
 
 namespace ScipBe.Common.Office.OneNote
@@ -16,58 +19,43 @@ namespace ScipBe.Common.Office.OneNote
     /// <item>Article: Querying Outlook and OneNote with LINQ : http://www.scip.be/index.php?Page=ArticlesNET05</item>
     /// </list>
     /// </remarks>
-    public class OneNoteProvider : IOneNoteProvider
+    public static class OneNoteProvider
     {
-        /// <summary>
-        /// Constructor. Create instance of Microsoft.Office.Interop.OneNote.Application and get XML hierarchy.
-        /// </summary>
-        public OneNoteProvider()
-        {
-            this.OneNote = new Microsoft.Office.Interop.OneNote.Application();
-        }
-
-        /// <summary>
-        /// Instance of OneNote Application object.
-        /// </summary>
-        /// <remarks>
-        /// <list type="bullet">
-        /// <item>http://msdn.microsoft.com/en-us/library/ms788684.aspx</item>
-        /// <item>http://msdn.microsoft.com/en-us/library/aa286798.aspx</item>
-        /// </list>
-        /// </remarks>
-        public Microsoft.Office.Interop.OneNote.Application OneNote { get; private set; }
-
         /// <summary>
         /// Hierarchy of Notebooks with Sections and Pages.
         /// </summary>
-        public IEnumerable<IOneNoteExtNotebook> NotebookItems
+        public static IEnumerable<IOneNoteExtNotebook> NotebookItems
         {
             get
             {
-                // Get OneNote hierarchy as XML document
-                this.OneNote.GetHierarchy(null, Microsoft.Office.Interop.OneNote.HierarchyScope.hsPages, out string oneNoteXMLHierarchy);
+                return CallOneNoteSafely(oneNote =>
+                {
+                    // Get OneNote hierarchy as XML document
+                    oneNote.GetHierarchy(null, HierarchyScope.hsPages, out string oneNoteXMLHierarchy);
+                    var oneNoteHierarchy = XElement.Parse(oneNoteXMLHierarchy);
+                    var one = oneNoteHierarchy.GetNamespaceOfPrefix("one");
 
-                var oneNoteHierarchy = XElement.Parse(oneNoteXMLHierarchy);
-                var one = oneNoteHierarchy.GetNamespaceOfPrefix("one");
-
-                // Transform XML into object hierarchy
-                return from n in oneNoteHierarchy.Elements(one + "Notebook")
-                       where n.HasAttributes
-                       select this.ParseNotebook(n, one, true);
+                    // Transform XML into object hierarchy
+                    return from n in oneNoteHierarchy.Elements(one + "Notebook")
+                           where n.HasAttributes
+                           select ParseNotebook(n, one, true);
+                });
             }
         }
 
         /// <summary>
         /// Collection of Pages.
         /// </summary>
-        public IEnumerable<IOneNoteExtPage> PageItems
+        public static IEnumerable<IOneNoteExtPage> PageItems
         {
             get
             {
-                // Get OneNote hierarchy as XML document
-                this.OneNote.GetHierarchy(null, Microsoft.Office.Interop.OneNote.HierarchyScope.hsPages, out string oneNoteXMLHierarchy);
-
-                return this.ParsePages(oneNoteXMLHierarchy);
+                return CallOneNoteSafely(oneNote =>
+                {
+                    // Get OneNote hierarchy as XML document
+                    oneNote.GetHierarchy(null, HierarchyScope.hsPages, out string oneNoteXMLHierarchy);
+                    return ParsePages(oneNoteXMLHierarchy);
+                });
             }
         }
 
@@ -75,14 +63,16 @@ namespace ScipBe.Common.Office.OneNote
         /// Returns a list of pages that match the specified query term.
         /// </summary>
         /// <param name="searchString">The search string. Pass exactly the same string that you would type into the search box in the OneNote UI. You can use bitwise operators, such as AND and OR, which must be all uppercase.</param>
-        public IEnumerable<IOneNoteExtPage> FindPages(string searchString)
+        public static  IEnumerable<IOneNoteExtPage> FindPages(string searchString)
         {
-            this.OneNote.FindPages(null, searchString, out string xml);
-
-            return this.ParsePages(xml);
+            return CallOneNoteSafely(oneNote =>
+            {
+                oneNote.FindPages(null, searchString, out string xml);
+                return ParsePages(xml);
+            });
         }
 
-        private IOneNoteExtNotebook ParseNotebook(XElement element, XNamespace oneNamespace, bool addSections)
+        private static IOneNoteExtNotebook ParseNotebook(XElement element, XNamespace oneNamespace, bool addSections)
         {
             var notebook = new OneNoteExtNotebook()
             {
@@ -95,13 +85,13 @@ namespace ScipBe.Common.Office.OneNote
 
             if (addSections)
             {
-                notebook.Sections = element.Elements(oneNamespace + "Section").Select(s => this.ParseSection(s, oneNamespace, true));
+                notebook.Sections = element.Elements(oneNamespace + "Section").Select(s => ParseSection(s, oneNamespace, true));
             }
 
             return notebook;
         }
 
-        private IOneNoteExtSection ParseSection(XElement element, XNamespace oneNamespace, bool addPages)
+        private static IOneNoteExtSection ParseSection(XElement element, XNamespace oneNamespace, bool addPages)
         {
             var section = new OneNoteExtSection()
             {
@@ -114,33 +104,36 @@ namespace ScipBe.Common.Office.OneNote
 
             if (addPages)
             {
-                section.Pages = element.Elements(oneNamespace + "Page").Select(p => this.ParsePage(p, oneNamespace, false));
+                section.Pages = element.Elements(oneNamespace + "Page").Select(p => ParsePage(p, oneNamespace, false));
             }
 
             return section;
         }
 
-        private IOneNoteExtPage ParsePage(XElement element, XNamespace oneNamespace, bool addParents)
+        private static IOneNoteExtPage ParsePage(XElement element, XNamespace oneNamespace, bool addParents)
         {
-            var page = new OneNoteExtPage(this.OneNote)
+            return CallOneNoteSafely(oneNote =>
             {
-                ID = element.Attribute("ID").Value,
-                Name = element.Attribute("name").Value,
-                Level = element.Attribute("pageLevel").Value.ToInt32(),
-                DateTime = element.Attribute("dateTime").Value.ToString().ToDateTime(),
-                LastModified = element.Attribute("lastModifiedTime").Value.ToString().ToDateTime(),
-            };
+                var page = new OneNoteExtPage(oneNote)
+                {
+                    ID = element.Attribute("ID").Value,
+                    Name = element.Attribute("name").Value,
+                    Level = element.Attribute("pageLevel").Value.ToInt32(),
+                    DateTime = element.Attribute("dateTime").Value.ToString().ToDateTime(),
+                    LastModified = element.Attribute("lastModifiedTime").Value.ToString().ToDateTime(),
+                };
 
-            if (addParents)
-            {
-                page.Section = this.ParseSection(element.Parent, oneNamespace, false);
-                page.Notebook = this.ParseNotebook(element.Parent.Parent, oneNamespace, false);
-            }
+                if (addParents)
+                {
+                    page.Section = ParseSection(element.Parent, oneNamespace, false);
+                    page.Notebook = ParseNotebook(element.Parent.Parent, oneNamespace, false);
+                }
 
-            return page;
+                return page;
+            });
         }
 
-        private IEnumerable<IOneNoteExtPage> ParsePages(string xml)
+        private static IEnumerable<IOneNoteExtPage> ParsePages(string xml)
         {
             var doc = XElement.Parse(xml);
             var one = doc.GetNamespaceOfPrefix("one");
@@ -149,7 +142,21 @@ namespace ScipBe.Common.Office.OneNote
             return from p in doc.Elements(one + "Notebook").Elements().Elements()
                    where p.HasAttributes
                    && p.Name.LocalName == "Page"
-                   select this.ParsePage(p, one, true);
+                   select ParsePage(p, one, true);
+        }
+
+        internal static T CallOneNoteSafely<T>(Func<Application, T> action)
+        {
+            Application oneNote = null;
+            try
+            {
+                oneNote = new Application();
+                return action(oneNote);
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(oneNote);
+            }
         }
     }
 }

--- a/Src/ScipBe.Common.Office/ScipBe.Common.Office.nuspec
+++ b/Src/ScipBe.Common.Office/ScipBe.Common.Office.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>ScipBe.Common.Office</id>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>Stefan Cruysberghs</authors>
 	  <summary>LINQ to Excel, LINQ to Outlook and LINQ to OneNote. Query data of Excel worksheets and CSV files, Outlook Mails, Appointments, Contacts, ... and OneNote Notebooks, Sections and Pages.</summary>
     <description>The ScipBe.Common.Office namespace contains 3 classes: ExcelProvider (LINQ to Excel), OutlookProvider (LINQ to Outlook) and OneNoteProvider (LINQ to OneNote). The ExcelProvider loads an Excel worksheet or CSV file and provides column definition and row collections. The OutlookProvider is a wrapper class which provides collections to data of Outlook (AppointmentItems, ContactItems, MailItems, TaskItems, ...). The OneNoteProvider provides collections of Notebooks, Sections and Pages by parsing the XML hierarchy tree of OneNote.  All collections are IEnumerable so you can query them with LINQ. There are also 3 separated NuGet packages with for the Excel, Outlook and OneNote provider so they can be used standalone.</description>
@@ -11,11 +11,15 @@
     <licenseUrl>https://github.com/scipbe/ScipBe-Common-Office/blob/master/LICENSE</licenseUrl>
     <iconUrl>https://github.com/scipbe/ScipBe-Common-Office/raw/master/Doc/Images/ScipBe.Common.Office.png</iconUrl>
     <releaseNotes>
-      Version 2.0.2 (May 2022)
+      Version 2.0.3 (May 2022)
       - Migrated to .NET Standard 2.0 to allow .NET Core projects to consume
       - Added FindPages API to OneNoteProvider, and OpenInOneNote method to OneNotePage
       - A couple bug fixes and improvements in the OneNote project and the unit tests
     </releaseNotes>
     <tags>scipbe linq office excel outlook onenote interop</tags>
+    <dependencies>
+      <dependency id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0" />
+      <dependency id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" />
+    </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Fixes #11 

As seen in the above issue, the current library has a bug in it where anytime an interop function is called, you can no longer open OneNote until a reboot. This seems to be because the COM wrapper isn't correctly released after use. This is impossible to enforce if we expose the interop library directly, so I'm removing that. Additionally, it's tricky if we try to do it lazily, for example, if we made the provider IDisposable and did it there. The problem is that until that's called, OneNote won't work, and the caller might be a long running process that doesn't call Dispose for a while. Additionally, if we make it disposable, then the PageItems are in a weird state, where you can no longer call OpenInOneNote() on them. To work around these issues, I propose switching the library to be static, and to wrap EVERY call in a try/finally to ensure that it gets freed immediately.